### PR TITLE
PR: Add CI with github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: published
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade check_manifest pip setuptools twine wheel
+    - name: Build release artefacts
+      run: |
+        check-manifest -v
+        python setup.py sdist bdist_wheel
+        python -m twine check dist/*
+    - name: Publish release
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python -m twine upload dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,84 @@
+name: Linux tests
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/*.yml'
+      - 'requirements/*.txt'
+      - 'Makefile'
+      - 'MANIFEST.in'
+      - '**.bat'
+      - '**.py'
+      - '**.sh'
+
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/*.yml'
+      - 'requirements/*.txt'
+      - 'MANIFEST.in'
+      - '**.bat'
+      - '**.py'
+      - '**.sh'
+
+jobs:
+  ############################################################################
+  # Close previous builds on the same branch
+  ############################################################################
+  cleanup-previous-runs:
+    name: Cleanup previous builds
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo $GITHUB_EVENT_NAME
+      - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  ############################################################################
+  # Python tests
+  ############################################################################
+  linux-py:
+    name: Linux py${{ matrix.PYTHON_VERSION }} tests
+    runs-on: ubuntu-latest
+    needs: cleanup-previous-runs
+    env:
+      CI: True
+      PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
+    strategy:
+      fail-fast: false 
+      matrix:
+        PYTHON_VERSION: ['2.7', '3.6', '3.7', '3.8']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cache pip
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-py-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('**/setup.py') }}
+      - name: Setup python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.PYTHON_VERSION }}
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade check-manifest codecov pip pre-commit setuptools
+          python -m pip install --editable .[test]
+          python -m pip install lektor
+      - name: Show python environment
+        run: |
+          python --version
+          python -m pip list
+      - name: Run python tests
+        run: |
+          pytest . --tb=long -svv
+      - name: Check manifest
+        run: |
+          check-manifest -v
+      # - name: Run pre commit checks
+      #   run: |
+      #     pre-commit run -a

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ build
 *.pyo
 *.egg-info
 .cache
+
+.DS_Store
+
+.coverage

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include *.md
+include *.yaml
+include Makefile
+recursive-include tests *.html
+recursive-include tests *.ini
+recursive-include tests *.lektorproject
+recursive-include tests *.lr
+recursive-include tests *.py

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Lektor Atom Plugin
 
+![Linux tests](https://github.com/lektor/lektor-atom/workflows/Linux%20tests/badge.svg)
+[![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Join the chat at https://gitter.im/lektor/lektor](https://badges.gitter.im/lektor/lektor.svg)](https://gitter.im/lektor/lektor?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 Builds one or more Atom XML feeds for your [Lektor](https://www.getlektor.com/)-based site.
 
 Inspired by the [atom-feed-support](https://github.com/lektor/lektor-website/tree/master/packages/atom-feed-support) plugin Armin Ronacher wrote for the Lektor official blog.
@@ -8,7 +12,7 @@ Inspired by the [atom-feed-support](https://github.com/lektor/lektor-website/tre
 
 Add lektor-atom to your project from command line:
 
-```
+```sh
 lektor plugins add lektor-atom
 ```
 
@@ -18,7 +22,7 @@ See [the Lektor documentation for more instructions on installing plugins](https
 
 Here is a basic configuration:
 
-```
+```ini
 [feed]
 name = My Site's Blog
 source_path = /blog
@@ -27,7 +31,7 @@ url_path = /feed.xml
 
 For each feed you want to publish, add a section to `configs/atom.ini`. For example, a blog with a feed of all recent posts, and a feed of recent posts about coffee:
 
-```
+```ini
 [blog]
 name = My Blog
 source_path = /
@@ -67,7 +71,7 @@ The section names, like `blog` and `coffee`, are just used as internal identifie
 
 Use the field options to tell lektor-atom how to read your items. For example, if your site's model is:
 
-```
+```ini
 [model]
 name = Blog
 
@@ -80,7 +84,7 @@ type = string
 
 Then add to atom.ini:
 
-```
+```ini
 [main]
 blog_author_field = writer
 blog_summary_field = short_description
@@ -98,7 +102,7 @@ Set `items` to any query expression to override the default. If `items_model` is
 
 You can link to a specific feed in your template. If your `atom.ini` contains a feed like this:
 
-```
+```ini
 [main]
 source_path = /blog
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,37 @@
+# Release
+
+* Update [CHANGELOG.md](https://github.com/lektor/lektor-atom/blob/master/CHANGELOG.md)
+
+* Update package version on [setup.py](https://github.com/lektor/lektor-atom/blob/master/setup.py)
+
+* Commit changes
+  ```bash
+  git add .
+  git commit -m "Prepare release version"
+  ```
+
+* Tag the release
+  ```bash
+  git tag -a vX.X.X -m "Version X.X.X"
+  ```
+
+* Push changes
+  ```bash
+  git push origin master
+  git push origin --tags
+  ```
+
+* The new tag will trigger a Github action workflow on CI and will create [pre release](https://github.com/lektor/lektor-atom/releases).
+
+* Once that release is moved from prerelease to release another Github Action will publish to PyPI using the `getlektor` account.
+
+## Retrigger events
+
+If the release process needs to be fixed or retriggered you will need to delete the tag and recreate it, or create a new tag from scratch.
+
+* To delete and recreate a tag:
+  ```bash
+  git push --delete origin refs/tags/<tag-name>
+  git tag -a <recreated-tag-name> -m "Version X.X.X"
+  git push origin --tags
+  ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [bdist_wheel]
 universal=1
+
+[check-manifest]
+ignore = 
+  .coverage

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,10 @@ setup(
     author=u'A. Jesse Jiryu Davis',
     author_email='jesse@emptysquare.net',
     description=description,
-    install_requires=['MarkupSafe'],
+    install_requires=[
+        'MarkupSafe',
+        'Werkzeug<1.0',  # Werkzeug 1.0 removed the feed generator
+    ],
     keywords='Lektor plugin static-site blog atom rss',
     license='MIT',
     long_description=readme,


### PR DESCRIPTION
Fixes #23

- [x] The setup.py dependency and adds CI with linux. (I think that is enough for now 🤷 ?)
- [x]  Add release and plublish workflows
- [x] Configure token for the pypi uploader account (getlektor)
- [x] Create tag with v prefix -> https://github.com/lektor/lektor-atom/tree/v0.3.1