### PR TITLE
Import werkzeug's atom.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.2 (June 13, 2020)
+
+- Bundle atom.py from old werkzeug's contrib.
+- Unpin werkzeug.
+
 ## 0.3.1 (May 11, 2020)
 
 - Pin werkzeug to be able to use the atom feed.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include *.md
 include *.yaml
 include Makefile
+recursive-include lektor_atom *.py
 recursive-include tests *.html
 recursive-include tests *.ini
 recursive-include tests *.lektorproject

--- a/lektor_atom/__init__.py
+++ b/lektor_atom/__init__.py
@@ -16,7 +16,8 @@ from lektor.pluginsystem import Plugin
 from lektor.sourceobj import VirtualSourceObject
 from lektor.utils import build_url
 from markupsafe import escape
-from werkzeug.contrib.atom import AtomFeed
+
+from .lib.atom import AtomFeed
 
 PY2 = sys.version_info[0] == 2
 

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -52,6 +52,7 @@ def format_iso8601(obj):
 
 @implements_to_string
 class AtomFeed(object):
+
     """A helper class that creates Atom feeds.
 
     :param title: the title of the feed. Required.
@@ -176,8 +177,8 @@ class AtomFeed(object):
             yield u'  <link href="%s" rel="self" />\n' % \
                 escape(self.feed_url)
         for link in self.links:
-            yield u'  <link %s/>\n' % ''.join('%s="%s" ' % \
-                (k, escape(link[k])) for k in link)
+            yield u'  <link %s/>\n' % ''.join('%s="%s" ' %
+                                              (k, escape(link[k])) for k in link)
         for author in self.author:
             yield u'  <author>\n'
             yield u'    <name>%s</name>\n' % escape(author['name'])
@@ -228,6 +229,7 @@ class AtomFeed(object):
 
 @implements_to_string
 class FeedEntry(object):
+
     """Represents a single entry in a feed.
 
     :param title: the title of the entry. Required.
@@ -332,11 +334,11 @@ class FeedEntry(object):
                 yield u'    <email>%s</email>\n' % escape(author['email'])
             yield u'  </author>\n'
         for link in self.links:
-            yield u'  <link %s/>\n' % ''.join('%s="%s" ' % \
-                (k, escape(link[k])) for k in link)
+            yield u'  <link %s/>\n' % ''.join('%s="%s" ' %
+                                              (k, escape(link[k])) for k in link)
         for category in self.categories:
-            yield u'  <category %s/>\n' % ''.join('%s="%s" ' % \
-                (k, escape(category[k])) for k in category)
+            yield u'  <category %s/>\n' % ''.join('%s="%s" ' %
+                                                  (k, escape(category[k])) for k in category)
         if self.summary:
             yield u'  ' + _make_text_block('summary', self.summary,
                                            self.summary_type)

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -159,7 +159,7 @@ class AtomFeed(object):
         """Return a generator that yields pieces of XML."""
         # atom demands either an author element in every entry or a global one
         if not self.author:
-            if False in map(lambda e: bool(e.author), self.entries):
+            if any(not e.author for e in self.entries):
                 self.author = ({'name': 'Unknown author'},)
 
         if not self.updated:

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -23,9 +23,11 @@
 """
 import warnings
 from datetime import datetime
-from werkzeug.utils import escape
-from werkzeug.wrappers import BaseResponse
-from werkzeug._compat import implements_to_string, string_types
+
+from .._compat import implements_to_string
+from .._compat import string_types
+from ..utils import escape
+from ..wrappers import BaseResponse
 
 warnings.warn(
     "'werkzeug.contrib.atom' is deprecated as of version 0.15 and will"
@@ -34,18 +36,21 @@ warnings.warn(
     stacklevel=2,
 )
 
-XHTML_NAMESPACE = 'http://www.w3.org/1999/xhtml'
+XHTML_NAMESPACE = "http://www.w3.org/1999/xhtml"
 
 
 def _make_text_block(name, content, content_type=None):
     """Helper function for the builder that creates an XML text block."""
-    if content_type == 'xhtml':
-        return u'<%s type="xhtml"><div xmlns="%s">%s</div></%s>\n' % \
-               (name, XHTML_NAMESPACE, content, name)
+    if content_type == "xhtml":
+        return u'<%s type="xhtml"><div xmlns="%s">%s</div></%s>\n' % (
+            name,
+            XHTML_NAMESPACE,
+            content,
+            name,
+        )
     if not content_type:
-        return u'<%s>%s</%s>\n' % (name, escape(content), name)
-    return u'<%s type="%s">%s</%s>\n' % (name, content_type,
-                                         escape(content), name)
+        return u"<%s>%s</%s>\n" % (name, escape(content), name)
+    return u'<%s type="%s">%s</%s>\n' % (name, content_type, escape(content), name)
 
 
 def format_iso8601(obj):
@@ -53,7 +58,7 @@ def format_iso8601(obj):
     iso8601 = obj.isoformat()
     if obj.tzinfo:
         return iso8601
-    return iso8601 + 'Z'
+    return iso8601 + "Z"
 
 
 @implements_to_string
@@ -106,42 +111,43 @@ class AtomFeed(object):
     Everywhere where a list is demanded, any iterable can be used.
     """
 
-    default_generator = ('Werkzeug', None, None)
+    default_generator = ("Werkzeug", None, None)
 
     def __init__(self, title=None, entries=None, **kwargs):
         self.title = title
-        self.title_type = kwargs.get('title_type', 'text')
-        self.url = kwargs.get('url')
-        self.feed_url = kwargs.get('feed_url', self.url)
-        self.id = kwargs.get('id', self.feed_url)
-        self.updated = kwargs.get('updated')
-        self.author = kwargs.get('author', ())
-        self.icon = kwargs.get('icon')
-        self.logo = kwargs.get('logo')
-        self.rights = kwargs.get('rights')
-        self.rights_type = kwargs.get('rights_type')
-        self.subtitle = kwargs.get('subtitle')
-        self.subtitle_type = kwargs.get('subtitle_type', 'text')
-        self.generator = kwargs.get('generator')
+        self.title_type = kwargs.get("title_type", "text")
+        self.url = kwargs.get("url")
+        self.feed_url = kwargs.get("feed_url", self.url)
+        self.id = kwargs.get("id", self.feed_url)
+        self.updated = kwargs.get("updated")
+        self.author = kwargs.get("author", ())
+        self.icon = kwargs.get("icon")
+        self.logo = kwargs.get("logo")
+        self.rights = kwargs.get("rights")
+        self.rights_type = kwargs.get("rights_type")
+        self.subtitle = kwargs.get("subtitle")
+        self.subtitle_type = kwargs.get("subtitle_type", "text")
+        self.generator = kwargs.get("generator")
         if self.generator is None:
             self.generator = self.default_generator
-        self.links = kwargs.get('links', [])
+        self.links = kwargs.get("links", [])
         self.entries = list(entries) if entries else []
 
-        if not hasattr(self.author, '__iter__') \
-           or isinstance(self.author, string_types + (dict,)):
+        if not hasattr(self.author, "__iter__") or isinstance(
+            self.author, string_types + (dict,)
+        ):
             self.author = [self.author]
         for i, author in enumerate(self.author):
             if not isinstance(author, dict):
-                self.author[i] = {'name': author}
+                self.author[i] = {"name": author}
 
         if not self.title:
-            raise ValueError('title is required')
+            raise ValueError("title is required")
         if not self.id:
-            raise ValueError('id is required')
+            raise ValueError("id is required")
         for author in self.author:
-            if 'name' not in author:
-                raise TypeError('author must contain at least a name')
+            if "name" not in author:
+                raise TypeError("author must contain at least a name")
 
     def add(self, *args, **kwargs):
         """Add a new entry to the feed.  This function can either be called
@@ -151,14 +157,14 @@ class AtomFeed(object):
         if len(args) == 1 and not kwargs and isinstance(args[0], FeedEntry):
             self.entries.append(args[0])
         else:
-            kwargs['feed_url'] = self.feed_url
+            kwargs["feed_url"] = self.feed_url
             self.entries.append(FeedEntry(*args, **kwargs))
 
     def __repr__(self):
-        return '<%s %r (%d entries)>' % (
+        return "<%s %r (%d entries)>" % (
             self.__class__.__name__,
             self.title,
-            len(self.entries)
+            len(self.entries),
         )
 
     def generate(self):
@@ -166,7 +172,7 @@ class AtomFeed(object):
         # atom demands either an author element in every entry or a global one
         if not self.author:
             if any(not e.author for e in self.entries):
-                self.author = ({'name': 'Unknown author'},)
+                self.author = ({"name": "Unknown author"},)
 
         if not self.updated:
             dates = sorted([entry.updated for entry in self.entries])
@@ -174,56 +180,54 @@ class AtomFeed(object):
 
         yield u'<?xml version="1.0" encoding="utf-8"?>\n'
         yield u'<feed xmlns="http://www.w3.org/2005/Atom">\n'
-        yield '  ' + _make_text_block('title', self.title, self.title_type)
-        yield u'  <id>%s</id>\n' % escape(self.id)
-        yield u'  <updated>%s</updated>\n' % format_iso8601(self.updated)
+        yield "  " + _make_text_block("title", self.title, self.title_type)
+        yield u"  <id>%s</id>\n" % escape(self.id)
+        yield u"  <updated>%s</updated>\n" % format_iso8601(self.updated)
         if self.url:
             yield u'  <link href="%s" />\n' % escape(self.url)
         if self.feed_url:
-            yield u'  <link href="%s" rel="self" />\n' % \
-                escape(self.feed_url)
+            yield u'  <link href="%s" rel="self" />\n' % escape(self.feed_url)
         for link in self.links:
-            yield u'  <link %s/>\n' % ''.join('%s="%s" ' %
-                                              (k, escape(link[k])) for k in link)
+            yield u"  <link %s/>\n" % "".join(
+                '%s="%s" ' % (k, escape(link[k])) for k in link
+            )
         for author in self.author:
-            yield u'  <author>\n'
-            yield u'    <name>%s</name>\n' % escape(author['name'])
-            if 'uri' in author:
-                yield u'    <uri>%s</uri>\n' % escape(author['uri'])
-            if 'email' in author:
-                yield '    <email>%s</email>\n' % escape(author['email'])
-            yield '  </author>\n'
+            yield u"  <author>\n"
+            yield u"    <name>%s</name>\n" % escape(author["name"])
+            if "uri" in author:
+                yield u"    <uri>%s</uri>\n" % escape(author["uri"])
+            if "email" in author:
+                yield "    <email>%s</email>\n" % escape(author["email"])
+            yield "  </author>\n"
         if self.subtitle:
-            yield '  ' + _make_text_block('subtitle', self.subtitle,
-                                          self.subtitle_type)
+            yield "  " + _make_text_block("subtitle", self.subtitle, self.subtitle_type)
         if self.icon:
-            yield u'  <icon>%s</icon>\n' % escape(self.icon)
+            yield u"  <icon>%s</icon>\n" % escape(self.icon)
         if self.logo:
-            yield u'  <logo>%s</logo>\n' % escape(self.logo)
+            yield u"  <logo>%s</logo>\n" % escape(self.logo)
         if self.rights:
-            yield '  ' + _make_text_block('rights', self.rights,
-                                          self.rights_type)
+            yield "  " + _make_text_block("rights", self.rights, self.rights_type)
         generator_name, generator_url, generator_version = self.generator
         if generator_name or generator_url or generator_version:
-            tmp = [u'  <generator']
+            tmp = [u"  <generator"]
             if generator_url:
                 tmp.append(u' uri="%s"' % escape(generator_url))
             if generator_version:
                 tmp.append(u' version="%s"' % escape(generator_version))
-            tmp.append(u'>%s</generator>\n' % escape(generator_name))
-            yield u''.join(tmp)
+            tmp.append(u">%s</generator>\n" % escape(generator_name))
+            yield u"".join(tmp)
         for entry in self.entries:
             for line in entry.generate():
-                yield u'  ' + line
-        yield u'</feed>\n'
+                yield u"  " + line
+        yield u"</feed>\n"
 
     def to_string(self):
         """Convert the feed into a string."""
-        return u''.join(self.generate())
+        return u"".join(self.generate())
 
     def get_response(self):
         """Return a response object for the feed."""
-        return BaseResponse(self.to_string(), mimetype='application/atom+xml')
+        return BaseResponse(self.to_string(), mimetype="application/atom+xml")
 
     def __call__(self, environ, start_response):
         """Use the class as WSGI response object."""
@@ -282,80 +286,77 @@ class FeedEntry(object):
 
     def __init__(self, title=None, content=None, feed_url=None, **kwargs):
         self.title = title
-        self.title_type = kwargs.get('title_type', 'text')
+        self.title_type = kwargs.get("title_type", "text")
         self.content = content
-        self.content_type = kwargs.get('content_type', 'html')
-        self.url = kwargs.get('url')
-        self.id = kwargs.get('id', self.url)
-        self.updated = kwargs.get('updated')
-        self.summary = kwargs.get('summary')
-        self.summary_type = kwargs.get('summary_type', 'html')
-        self.author = kwargs.get('author', ())
-        self.published = kwargs.get('published')
-        self.rights = kwargs.get('rights')
-        self.links = kwargs.get('links', [])
-        self.categories = kwargs.get('categories', [])
-        self.xml_base = kwargs.get('xml_base', feed_url)
+        self.content_type = kwargs.get("content_type", "html")
+        self.url = kwargs.get("url")
+        self.id = kwargs.get("id", self.url)
+        self.updated = kwargs.get("updated")
+        self.summary = kwargs.get("summary")
+        self.summary_type = kwargs.get("summary_type", "html")
+        self.author = kwargs.get("author", ())
+        self.published = kwargs.get("published")
+        self.rights = kwargs.get("rights")
+        self.links = kwargs.get("links", [])
+        self.categories = kwargs.get("categories", [])
+        self.xml_base = kwargs.get("xml_base", feed_url)
 
-        if not hasattr(self.author, '__iter__') \
-           or isinstance(self.author, string_types + (dict,)):
+        if not hasattr(self.author, "__iter__") or isinstance(
+            self.author, string_types + (dict,)
+        ):
             self.author = [self.author]
         for i, author in enumerate(self.author):
             if not isinstance(author, dict):
-                self.author[i] = {'name': author}
+                self.author[i] = {"name": author}
 
         if not self.title:
-            raise ValueError('title is required')
+            raise ValueError("title is required")
         if not self.id:
-            raise ValueError('id is required')
+            raise ValueError("id is required")
         if not self.updated:
-            raise ValueError('updated is required')
+            raise ValueError("updated is required")
 
     def __repr__(self):
-        return '<%s %r>' % (
-            self.__class__.__name__,
-            self.title
-        )
+        return "<%s %r>" % (self.__class__.__name__, self.title)
 
     def generate(self):
         """Yields pieces of ATOM XML."""
-        base = ''
+        base = ""
         if self.xml_base:
             base = ' xml:base="%s"' % escape(self.xml_base)
-        yield u'<entry%s>\n' % base
-        yield u'  ' + _make_text_block('title', self.title, self.title_type)
-        yield u'  <id>%s</id>\n' % escape(self.id)
-        yield u'  <updated>%s</updated>\n' % format_iso8601(self.updated)
+        yield u"<entry%s>\n" % base
+        yield u"  " + _make_text_block("title", self.title, self.title_type)
+        yield u"  <id>%s</id>\n" % escape(self.id)
+        yield u"  <updated>%s</updated>\n" % format_iso8601(self.updated)
         if self.published:
-            yield u'  <published>%s</published>\n' % \
-                  format_iso8601(self.published)
+            yield u"  <published>%s</published>\n" % format_iso8601(self.published)
         if self.url:
             yield u'  <link href="%s" />\n' % escape(self.url)
         for author in self.author:
-            yield u'  <author>\n'
-            yield u'    <name>%s</name>\n' % escape(author['name'])
-            if 'uri' in author:
-                yield u'    <uri>%s</uri>\n' % escape(author['uri'])
-            if 'email' in author:
-                yield u'    <email>%s</email>\n' % escape(author['email'])
-            yield u'  </author>\n'
+            yield u"  <author>\n"
+            yield u"    <name>%s</name>\n" % escape(author["name"])
+            if "uri" in author:
+                yield u"    <uri>%s</uri>\n" % escape(author["uri"])
+            if "email" in author:
+                yield u"    <email>%s</email>\n" % escape(author["email"])
+            yield u"  </author>\n"
         for link in self.links:
-            yield u'  <link %s/>\n' % ''.join('%s="%s" ' %
-                                              (k, escape(link[k])) for k in link)
+            yield u"  <link %s/>\n" % "".join(
+                '%s="%s" ' % (k, escape(link[k])) for k in link
+            )
         for category in self.categories:
-            yield u'  <category %s/>\n' % ''.join('%s="%s" ' %
-                                                  (k, escape(category[k])) for k in category)
+            yield u"  <category %s/>\n" % "".join(
+                '%s="%s" ' % (k, escape(category[k])) for k in category
+            )
         if self.summary:
-            yield u'  ' + _make_text_block('summary', self.summary,
-                                           self.summary_type)
+            yield u"  " + _make_text_block("summary", self.summary, self.summary_type)
         if self.content:
-            yield u'  ' + _make_text_block('content', self.content,
-                                           self.content_type)
-        yield u'</entry>\n'
+            yield u"  " + _make_text_block("content", self.content, self.content_type)
+        yield u"</entry>\n"
 
     def to_string(self):
         """Convert the feed item into a unicode object."""
-        return u''.join(self.generate())
+        return u"".join(self.generate())
 
     def __str__(self):
         return self.to_string()

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -6,7 +6,7 @@
     This module provides a class called `AtomFeed` which can be used
     to generate Atom feeds.
 
-    :copyright: Copyright 2007-2008 by Armin Ronacher, Marian Sigler.
+    :copyright: (c) 2008 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD.
 """
 from datetime import datetime

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -21,11 +21,17 @@
     :copyright: (c) 2014 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
+import warnings
 from datetime import datetime
-
 from werkzeug.utils import escape
 from werkzeug.wrappers import BaseResponse
 from werkzeug._compat import implements_to_string, string_types
+
+warnings.warn(
+    'werkzeug.contrib.atom is deprecated as of version 0.15 and will'
+    ' be removed in version 1.0.',
+    DeprecationWarning,
+)
 
 
 XHTML_NAMESPACE = 'http://www.w3.org/1999/xhtml'

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -9,8 +9,8 @@
     Example::
 
         def atom_feed(request):
-            feed = AtomFeed("My Blog", feed_url=req.url,
-                            url=req.host_url,
+            feed = AtomFeed("My Blog", feed_url=request.url,
+                            url=request.host_url,
                             subtitle="My example blog for a feed test.")
             for post in Post.query.limit(10).all():
                 feed.add(post.title, post.body, content_type='html',
@@ -170,7 +170,7 @@ class AtomFeed(object):
                 escape(self.feed_url, True)
         for link in self.links:
             yield u'  <link %s/>\n' % ''.join('%s="%s" ' % \
-                [(k, escape(link[k], True)) for k in link])
+                (k, escape(link[k], True)) for k in link)
         for author in self.author:
             yield u'  <author>\n'
             yield u'    <name>%s</name>\n' % escape(author['name'])
@@ -323,7 +323,7 @@ class FeedEntry(object):
             yield u'  </author>\n'
         for link in self.links:
             yield u'  <link %s/>\n' % ''.join('%s="%s" ' % \
-                [(k, escape(link[k], True)) for k in link])
+                (k, escape(link[k], True)) for k in link)
         if self.summary:
             yield u'  ' + _make_text_block('summary', self.summary,
                                            self.summary_type)

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -148,7 +148,7 @@ class AtomFeed(object):
                 self.author = ({'name': u'unbekannter Autor'},)
 
         if not self.updated:
-            dates = sorted(entry.updated for entry in self.entries)
+            dates = sorted([entry.updated for entry in self.entries])
             self.updated = dates and dates[-1] or datetime.utcnow()
 
         yield u'<?xml version="1.0" encoding="utf-8"?>\n'
@@ -163,7 +163,7 @@ class AtomFeed(object):
                 escape(self.feed_url, True)
         for link in self.links:
             yield u'  <link %s/>\n' % ''.join('%s="%s" ' % \
-                (k, escape(link[k], True)) for k in link)
+                [(k, escape(link[k], True)) for k in link])
         for author in self.author:
             yield u'  <author>\n'
             yield u'    <name>%s</name>\n' % escape(author['name'])
@@ -330,7 +330,7 @@ class FeedEntry(object):
             yield u'  </author>\n'
         for link in self.links:
             yield u'  <link %s/>\n' % ''.join('%s="%s" ' % \
-                (k, escape(link[k], True)) for k in link)
+                [(k, escape(link[k], True)) for k in link])
         if self.summary:
             yield u'  ' + _make_text_block('summary', self.summary,
                                            self.summary_type)

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -6,7 +6,7 @@
     This module provides a class called `AtomFeed` which can be used
     to generate Atom feeds.
 
-    :copyright: (c) 2008 by the Werkzeug Team, see AUTHORS for more details.
+    :copyright: (c) 2009 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD.
 """
 from datetime import datetime

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -131,6 +131,7 @@ class AtomFeed(object):
         if len(args) == 1 and not kwargs and isinstance(args[0], FeedEntry):
             self.entries.append(args[0])
         else:
+            kwargs['feed_url'] = self.feed_url
             self.entries.append(FeedEntry(*args, **kwargs))
 
     def __repr__(self):
@@ -218,7 +219,7 @@ class AtomFeed(object):
 class FeedEntry(object):
     """Represents a single entry in a feed."""
 
-    def __init__(self, title=None, content=None, **kwargs):
+    def __init__(self, title=None, content=None, feed_url=None, **kwargs):
         """Holds an Atom feed entry.
 
         :Parameters:
@@ -284,7 +285,7 @@ class FeedEntry(object):
         self.published = kwargs.get('published')
         self.rights = kwargs.get('rights')
         self.links = kwargs.get('links', [])
-        self.xml_base = kwargs.get('xml_base', self.url)
+        self.xml_base = kwargs.get('xml_base', feed_url)
 
         if not hasattr(self.author, '__iter__') \
            or isinstance(self.author, (basestring, dict)):

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -30,7 +30,7 @@ def _make_text_block(name, content, content_type=None):
 
 def format_iso8601(obj):
     """Format a datetime object for iso8601"""
-    return obj.strftime('%Y-%d-%mT%H:%M:%SZ')
+    return obj.strftime('%Y-%m-%dT%H:%M:%SZ')
 
 
 class AtomFeed(object):

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -207,7 +207,7 @@ class AtomFeed(object):
 
     def __call__(self, environ, start_response):
         """Use the class as WSGI response object."""
-        return self.get_response(environ, start_response)
+        return self.get_response()(environ, start_response)
 
     def __unicode__(self):
         return self.to_string()

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -28,11 +28,11 @@ from werkzeug.wrappers import BaseResponse
 from werkzeug._compat import implements_to_string, string_types
 
 warnings.warn(
-    'werkzeug.contrib.atom is deprecated as of version 0.15 and will'
-    ' be removed in version 1.0.',
+    "'werkzeug.contrib.atom' is deprecated as of version 0.15 and will"
+    " be removed in version 1.0.",
     DeprecationWarning,
+    stacklevel=2,
 )
-
 
 XHTML_NAMESPACE = 'http://www.w3.org/1999/xhtml'
 

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -33,6 +33,7 @@ class AtomFeed(object):
     """
     A helper class that creates ATOM feeds.
     """
+    default_generator = ('Werkzeug', None, None)
 
     def __init__(self, title=None, entries=None, **kwargs):
         """
@@ -105,7 +106,7 @@ class AtomFeed(object):
         self.subtitle_type = kwargs.get('subtitle_type')
         self.generator = kwargs.get('generator')
         if self.generator is None:
-            self.generator = ('Werkzeug', None, None)
+            self.generator = self.default_generator
         self.links = kwargs.get('links', [])
         self.entries = entries and list(entries) or []
 

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -1,0 +1,351 @@
+# -*- coding: utf-8 -*-
+"""
+    werkzeug.contrib.atom
+    ~~~~~~~~~~~~~~~~~~~~~
+
+    This module provides a class called `AtomFeed` which can be used
+    to generate Atom feeds.
+
+    :copyright: Copyright 2007 by Armin Ronacher.
+    :license: GNU GPL.
+"""
+from datetime import datetime
+from werkzeug.utils import escape
+from werkzeug.wrappers import BaseResponse
+
+
+def _make_text_block(name, content, content_type=None):
+    """Helper function for the builder that creates an XML text block."""
+    if content_type == 'xhtml':
+        return u'<%s type="xhtml">%s</%s>\n' % (name, content, anem)
+    if not content_type:
+        return u'<%s>%s</%s>\n' % (name, escape(content), name)
+    return u'<%s type="%s">%s</%s>\n' % (name, content_type,
+                                         escape(content), name)
+
+
+def format_iso8601(obj):
+    """Format a datetime object for iso8601"""
+    return obj.strftime('%Y-%d-%mT%H:%M:%SZ')
+
+
+class AtomFeed(object):
+    """
+    A helper class that creates ATOM feeds.
+    """
+
+    def __init__(self, title=None, entries=None, **kwargs):
+        """
+        Create an atom feed.
+
+        :Parameters:
+          title
+            the title of the feed. Required.
+          title_type
+            the type attribute for the title element. One of html, text,
+            xhtml. Default is text.
+          url
+            the url for the feed (not the url *of* the feed)
+          id
+            a globally unique id for the feed. Must be an URI. If not present
+            the `feed_url` is used, but one of both is required.
+          updated
+            the time the feed was modified the last time. Must be a `datetime`
+            object. If not present the latest entry's `updated` is used.
+          feed_url
+            the url to the feed. Should be the URL that was requested.
+          author
+            the author of the feed. Must be either a string (the name) or a
+            dict with name (required) and uri or email (both optional). Can be
+            a list of (may be mixed, too) strings and dicts, too, if there are
+            multiple authors. Required if not every entry has an author
+            element.
+          icon
+            an icon for the feed.
+          logo
+            a logo for the feed.
+          rights
+            copyright information for the feed.
+          rights_type
+            the type attribute for the rights element. One of html, text,
+            xhtml. Default is text.
+          subtitle
+            a short description of the feed.
+          subtitle_type
+            the type attribute for the subtitle element. One of html, text,
+            xhtml. Default is text.
+          links
+            additional links. Must be a list of dictionaries with href
+            (required) and rel, type, hreflang, title, length (all optional)
+          generator
+            the software that generated this feed.  This must be a tuple in
+            the form ``(name, url, version)``.  If you don't want to specify
+            one of them, set the item to None.
+          entries
+            a list with the entries for the feed. Entries can also be added
+            later with add().
+
+        For more information on the elements see
+        http://www.atomenabled.org/developers/syndication/
+
+        Everywhere where a list is demanded, any iterable can be used.
+        """
+        self.title = title
+        self.title_type = kwargs.get('title_type')
+        self.url = kwargs.get('url')
+        self.feed_url = kwargs.get('feed_url', self.url)
+        self.id = kwargs.get('id', self.feed_url)
+        self.updated = kwargs.get('updated')
+        self.author = kwargs.get('author', ())
+        self.icon = kwargs.get('icon')
+        self.logo = kwargs.get('logo')
+        self.rights = kwargs.get('rights')
+        self.rights_type = kwargs.get('rights_type')
+        self.subtitle = kwargs.get('subtitle')
+        self.subtitle_type = kwargs.get('subtitle_type')
+        self.generator = kwargs.get('generator')
+        if self.generator is None:
+            self.generator = ('Werkzeug', None, None)
+        self.links = kwargs.get('links', [])
+        self.entries = entries and list(entries) or []
+
+        if not hasattr(self.author, '__iter__') \
+           or isinstance(self.author, (basestring, dict)):
+            self.author = [self.author]
+        for i, author in enumerate(self.author):
+            if not isinstance(author, dict):
+                self.author[i] = {'name': author}
+
+        if not self.title:
+            raise ValueError('title is required')
+        if not self.id:
+            raise ValueError('id is required')
+        for author in self.author:
+            if 'name' not in author:
+                raise TypeError('author must contain at least a name')
+
+    def add(self, *args, **kwargs):
+        """add a new entry to the feed"""
+        if len(args) == 1 and not kwargs and isinstance(args[0], FeedEntry):
+            self.entries.append(args[0])
+        else:
+            self.entries.append(FeedEntry(*args, **kwargs))
+
+    def __repr__(self):
+        return '<%s %r (%d entries)>' % (
+            self.__class__.__name__,
+            self.title,
+            len(self.entries)
+        )
+
+    def generate(self):
+        """Return a generator that yields pieces of XML."""
+        # atom demands either an author element in every entry or a global one
+        if not self.author:
+            if False in map(lambda e: bool(e.author), self.entries):
+                self.author = ({'name': u'unbekannter Autor'},)
+
+        if not self.updated:
+            dates = sorted(entry.updated for entry in self.entries)
+            self.updated = dates and dates[-1] or datetime.utcnow()
+
+        yield u'<?xml version="1.0" encoding="utf-8"?>\n'
+        yield u'<feed xmlns="http://www.w3.org/2005/Atom">\n'
+        yield '  ' + _make_text_block('title', self.title, self.title_type)
+        yield u'  <id>%s</id>\n' % escape(self.id)
+        yield u'  <updated>%s</updated>\n' % format_iso8601(self.updated)
+        if self.url:
+            yield u'  <link href="%s" />\n' % escape(self.url, True)
+        if self.feed_url:
+            yield u'  <link href="%s" rel="self" />\n' % \
+                escape(self.feed_url, True)
+        for link in self.links:
+            yield u'  <link %s/>\n' % ''.join('%s="%s" ' % \
+                (k, escape(link[k], True)) for k in link)
+        for author in self.author:
+            yield u'  <author>\n'
+            yield u'    <name>%s</name>\n' % escape(author['name'])
+            if 'uri' in author:
+                yield u'    <uri>%s</uri>\n' % escape(author['uri'])
+            if 'email' in author:
+                yield '    <email>%s</email>\n' % escape(author['email'])
+            yield '  </author>\n'
+        if self.subtitle:
+            yield '  ' + _make_text_block('subtitle', self.subtitle,
+                                          self.subtitle_type)
+        if self.icon:
+            yield u'  <icon>%s</icon>\n' % escape(self.icon)
+        if self.logo:
+            yield u'  <logo>%s</logo>\n' % escape(self.logo)
+        if self.rights:
+            yield '  ' + _make_text_block('rights', self.rights,
+                                          self.rights_type)
+        generator_name, generator_url, generator_version = self.generator
+        if generator_name or generator_url or generator_version:
+            tmp = [u'  <generator']
+            if generator_url:
+                tmp.append(u' uri="%s"' % escape(generator_url, True))
+            if generator_version:
+                tmp.append(u' version="%s"' % escape(generator_version, True))
+            tmp.append(u'>%s</generator>\n' % escape(generator_name))
+            yield u''.join(tmp)
+        for entry in self.entries:
+            for line in entry.generate():
+                yield u'  ' + line
+        yield u'</feed>\n'
+
+    def to_string(self):
+        """Convert the feed into a string."""
+        return u''.join(self.generate())
+
+    def get_response(self):
+        """Return a response object for the feed."""
+        return BaseResponse(self.to_string(), mimetype='application/atom+xml')
+
+    def __call__(self, environ, start_response):
+        """Use the class as WSGI response object."""
+        return self.get_response(environ, start_response)
+
+    def __unicode__(self):
+        return self.to_string()
+
+    def __str__(self):
+        return self.to_string().encode('utf-8')
+
+
+class FeedEntry(object):
+    """
+    Represents a single entry in a feed.
+    """
+
+    def __init__(self, title=None, content=None, **kwargs):
+        """
+        Holds an atom feed entry.
+
+        :Parameters:
+          title
+            the title of the entry. Required.
+          title_type
+            the type attribute for the title element. One of html, text,
+            xhtml. Default is text.
+          content
+            the content of the entry.
+          content_type
+            the type attribute for the content element. One of html, text,
+            xhtml. Default is text.
+          summary
+            a summary of the entry's content.
+          summary_type
+            a type attribute for the summary element. One of html, text,
+            xhtml. Default is text.
+          url
+            the url for the entry.
+          id
+            a globally unique id for the entry. Must be an URI. If not present
+            the URL is used, but one of both is required.
+          updated
+            the time the entry was modified the last time. Must be a
+            `datetime` object. Required.
+          author
+            the author of the entry. Must be either a string (the name) or a
+            dict with name (required) and uri or email (both optional). Can
+            be a list of (may be mixed, too) strings and dicts, too, if there
+            are multiple authors. Required if there is no author for the
+            feed.
+          published
+            the time the entry was initially published. Must be a `datetime`
+            object.
+          rights
+            copyright information for the entry.
+          rights_type
+            the type attribute for the rights element. One of html, text,
+            xhtml. Default is text.
+          links
+            additional links. Must be a list of dictionaries with href
+            (required) and rel, type, hreflang, title, length (all optional)
+          xml_base
+            The xml base (url) for this feed item.  If not provided it will
+            default to the item url.
+
+        For more information on the elements see
+        http://www.atomenabled.org/developers/syndication/
+
+        Everywhere where a list is demanded, any iterable can be used.
+        """
+        self.title = title
+        self.title_type = kwargs.get('title_type', 'html')
+        self.content = content
+        self.content_type = kwargs.get('content_type', 'html')
+        self.url = kwargs.get('url')
+        self.id = kwargs.get('id', self.url)
+        self.updated = kwargs.get('updated')
+        self.summary = kwargs.get('summary')
+        self.summary_type = kwargs.get('summary_type', 'html')
+        self.author = kwargs.get('author')
+        self.published = kwargs.get('published')
+        self.rights = kwargs.get('rights')
+        self.links = kwargs.get('links', [])
+        self.xml_base = kwargs.get('xml_base', self.url)
+
+        if not hasattr(self.author, '__iter__') \
+           or isinstance(self.author, (basestring, dict)):
+            self.author = [self.author]
+        for i, author in enumerate(self.author):
+            if not isinstance(author, dict):
+                self.author[i] = {'name': author}
+
+        if not self.title:
+            raise ValueError('title is required')
+        if not self.id:
+            raise ValueError('id is required')
+        if not self.updated:
+            raise ValueError('updated is required')
+
+    def __repr__(self):
+        return '<%s %r>' % (
+            self.__class__.__name__,
+            self.title
+        )
+
+    def generate(self):
+        """Yields pieces of ATOM XML."""
+        base = ''
+        if self.xml_base:
+            base = ' xml:base="%s"' % escape(self.xml_base, True)
+        yield u'<entry%s>\n' % base
+        yield u'  ' + _make_text_block('title', self.title, self.title_type)
+        yield u'  <id>%s</id>\n' % escape(self.id)
+        yield u'  <updated>%s</updated>\n' % format_iso8601(self.updated)
+        if self.published:
+            yield u'  <published>%s</published>\n' % \
+                  format_iso8601(self.published)
+        if self.url:
+            yield u'  <link href="%s" />\n' % escape(self.url)
+        for author in self.author:
+            yield u'  <author>\n'
+            yield u'    <name>%s</name>\n' % escape(author['name'])
+            if 'uri' in author:
+                yield u'    <uri>%s</uri>\n' % escape(author['uri'])
+            if 'email' in author:
+                yield u'    <email>%s</email>\n' % escape(author['email'])
+            yield u'  </author>\n'
+        for link in self.links:
+            yield u'  <link %s/>\n' % ''.join('%s="%s" ' % \
+                (k, escape(link[k], True)) for k in link)
+        if self.summary:
+            yield u'  ' + _make_text_block('summary', self.summary,
+                                           self.summary_type)
+        if self.content:
+            yield u'  ' + _make_text_block('content', self.content,
+                                           self.content_type)
+        yield u'</entry>\n'
+
+    def to_string(self):
+        """Convert the feed item into a unicode object."""
+        return u''.join(self.generate())
+
+    def __unicode__(self):
+        return self.to_string()
+
+    def __str__(self):
+        return self.to_string().encode('utf-8')

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -3,11 +3,13 @@
     werkzeug.contrib.atom
     ~~~~~~~~~~~~~~~~~~~~~
 
-    This module provides a class called `AtomFeed` which can be used
-    to generate Atom feeds.
+    This module provides a class called `AtomFeed` which can be used to
+    generate feeds in the Atom syndication format (see `RFC 4287`_).
+
+    .. _RFC 4287: http://tools.ietf.org/html/rfc4287
 
     :copyright: (c) 2009 by the Werkzeug Team, see AUTHORS for more details.
-    :license: BSD.
+    :license: BSD, see LICENSE for more details.
 """
 from datetime import datetime
 from werkzeug.utils import escape

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -96,7 +96,7 @@ class AtomFeed(object):
         Everywhere where a list is demanded, any iterable can be used.
         """
         self.title = title
-        self.title_type = kwargs.get('title_type')
+        self.title_type = kwargs.get('title_type', 'text')
         self.url = kwargs.get('url')
         self.feed_url = kwargs.get('feed_url', self.url)
         self.id = kwargs.get('id', self.feed_url)

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -4,9 +4,7 @@
     ~~~~~~~~~~~~~~~~~~~~~
 
     This module provides a class called :class:`AtomFeed` which can be
-    used to generate feeds in the Atom syndication format (see `RFC 4287`_).
-
-    .. _RFC 4287: http://tools.ietf.org/html/rfc4287
+    used to generate feeds in the Atom syndication format (see :rfc:`4287`).
 
     Example::
 

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -34,14 +34,11 @@ def format_iso8601(obj):
 
 
 class AtomFeed(object):
-    """
-    A helper class that creates ATOM feeds.
-    """
+    """A helper class that creates Atom feeds."""
     default_generator = ('Werkzeug', None, None)
 
     def __init__(self, title=None, entries=None, **kwargs):
-        """
-        Create an atom feed.
+        """Create an Atom feed.
 
         :Parameters:
           title
@@ -219,13 +216,10 @@ class AtomFeed(object):
 
 
 class FeedEntry(object):
-    """
-    Represents a single entry in a feed.
-    """
+    """Represents a single entry in a feed."""
 
     def __init__(self, title=None, content=None, **kwargs):
-        """
-        Holds an atom feed entry.
+        """Holds an Atom feed entry.
 
         :Parameters:
           title

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -104,7 +104,7 @@ class AtomFeed(object):
         self.rights = kwargs.get('rights')
         self.rights_type = kwargs.get('rights_type')
         self.subtitle = kwargs.get('subtitle')
-        self.subtitle_type = kwargs.get('subtitle_type')
+        self.subtitle_type = kwargs.get('subtitle_type', 'text')
         self.generator = kwargs.get('generator')
         if self.generator is None:
             self.generator = self.default_generator
@@ -272,7 +272,7 @@ class FeedEntry(object):
         Everywhere where a list is demanded, any iterable can be used.
         """
         self.title = title
-        self.title_type = kwargs.get('title_type', 'html')
+        self.title_type = kwargs.get('title_type', 'text')
         self.content = content
         self.content_type = kwargs.get('content_type', 'html')
         self.url = kwargs.get('url')

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -6,8 +6,8 @@
     This module provides a class called `AtomFeed` which can be used
     to generate Atom feeds.
 
-    :copyright: Copyright 2007 by Armin Ronacher, Marian Sigler.
-    :license: GNU GPL.
+    :copyright: Copyright 2007-2008 by Armin Ronacher, Marian Sigler.
+    :license: BSD.
 """
 from datetime import datetime
 from werkzeug.utils import escape

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -18,8 +18,8 @@
                          updated=post.last_update, published=post.pub_date)
             return feed.get_response()
 
-    :copyright: (c) 2014 by the Werkzeug Team, see AUTHORS for more details.
-    :license: BSD, see LICENSE for more details.
+    :copyright: 2007 Pallets
+    :license: BSD-3-Clause
 """
 import warnings
 from datetime import datetime

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -6,7 +6,7 @@
     This module provides a class called `AtomFeed` which can be used
     to generate Atom feeds.
 
-    :copyright: Copyright 2007 by Armin Ronacher.
+    :copyright: Copyright 2007 by Armin Ronacher, Marian Sigler.
     :license: GNU GPL.
 """
 from datetime import datetime

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -18,7 +18,7 @@
                          updated=post.last_update, published=post.pub_date)
             return feed.get_response()
 
-    :copyright: (c) 2013 by the Werkzeug Team, see AUTHORS for more details.
+    :copyright: (c) 2014 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
 from datetime import datetime

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -239,11 +239,11 @@ class FeedEntry(object):
                not present the URL is used, but one of both is required.
     :param updated: the time the entry was modified the last time.  Must
                     be a :class:`datetime.datetime` object. Required.
-    :param author: the author of the feed.  Must be either a string (the
+    :param author: the author of the entry.  Must be either a string (the
                    name) or a dict with name (required) and uri or
                    email (both optional).  Can be a list of (may be
                    mixed, too) strings and dicts, too, if there are
-                   multiple authors. Required if not every entry has an
+                   multiple authors. Required if the feed does not have an
                    author element.
     :param published: the time the entry was initially published.  Must
                       be a :class:`datetime.datetime` object.

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -18,7 +18,7 @@
                          updated=post.last_update, published=post.pub_date)
             return feed.get_response()
 
-    :copyright: (c) 2009 by the Werkzeug Team, see AUTHORS for more details.
+    :copyright: (c) 2010 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
 from datetime import datetime

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -167,13 +167,13 @@ class AtomFeed(object):
         yield u'  <id>%s</id>\n' % escape(self.id)
         yield u'  <updated>%s</updated>\n' % format_iso8601(self.updated)
         if self.url:
-            yield u'  <link href="%s" />\n' % escape(self.url, True)
+            yield u'  <link href="%s" />\n' % escape(self.url)
         if self.feed_url:
             yield u'  <link href="%s" rel="self" />\n' % \
-                escape(self.feed_url, True)
+                escape(self.feed_url)
         for link in self.links:
             yield u'  <link %s/>\n' % ''.join('%s="%s" ' % \
-                (k, escape(link[k], True)) for k in link)
+                (k, escape(link[k])) for k in link)
         for author in self.author:
             yield u'  <author>\n'
             yield u'    <name>%s</name>\n' % escape(author['name'])
@@ -196,9 +196,9 @@ class AtomFeed(object):
         if generator_name or generator_url or generator_version:
             tmp = [u'  <generator']
             if generator_url:
-                tmp.append(u' uri="%s"' % escape(generator_url, True))
+                tmp.append(u' uri="%s"' % escape(generator_url))
             if generator_version:
-                tmp.append(u' version="%s"' % escape(generator_version, True))
+                tmp.append(u' version="%s"' % escape(generator_version))
             tmp.append(u'>%s</generator>\n' % escape(generator_name))
             yield u''.join(tmp)
         for entry in self.entries:
@@ -307,7 +307,7 @@ class FeedEntry(object):
         """Yields pieces of ATOM XML."""
         base = ''
         if self.xml_base:
-            base = ' xml:base="%s"' % escape(self.xml_base, True)
+            base = ' xml:base="%s"' % escape(self.xml_base)
         yield u'<entry%s>\n' % base
         yield u'  ' + _make_text_block('title', self.title, self.title_type)
         yield u'  <id>%s</id>\n' % escape(self.id)
@@ -327,10 +327,10 @@ class FeedEntry(object):
             yield u'  </author>\n'
         for link in self.links:
             yield u'  <link %s/>\n' % ''.join('%s="%s" ' % \
-                (k, escape(link[k], True)) for k in link)
+                (k, escape(link[k])) for k in link)
         for category in self.categories:
             yield u'  <category %s/>\n' % ''.join('%s="%s" ' % \
-                (k, escape(category[k], True)) for k in category)
+                (k, escape(category[k])) for k in category)
         if self.summary:
             yield u'  ' + _make_text_block('summary', self.summary,
                                            self.summary_type)

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -25,6 +25,7 @@ from datetime import datetime
 from six import string_types
 from werkzeug.utils import escape
 from werkzeug.wrappers import BaseResponse
+from werkzeug._compat import implements_to_string
 
 
 XHTML_NAMESPACE = 'http://www.w3.org/1999/xhtml'
@@ -46,6 +47,7 @@ def format_iso8601(obj):
     return obj.strftime('%Y-%m-%dT%H:%M:%SZ')
 
 
+@implements_to_string
 class AtomFeed(object):
     """A helper class that creates Atom feeds.
 
@@ -216,13 +218,11 @@ class AtomFeed(object):
         """Use the class as WSGI response object."""
         return self.get_response()(environ, start_response)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.to_string()
 
-    def __str__(self):
-        return self.to_string().encode('utf-8')
 
-
+@implements_to_string
 class FeedEntry(object):
     """Represents a single entry in a feed.
 
@@ -343,8 +343,5 @@ class FeedEntry(object):
         """Convert the feed item into a unicode object."""
         return u''.join(self.generate())
 
-    def __unicode__(self):
-        return self.to_string()
-
     def __str__(self):
-        return self.to_string().encode('utf-8')
+        return self.to_string()

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -275,7 +275,7 @@ class FeedEntry(object):
         self.updated = kwargs.get('updated')
         self.summary = kwargs.get('summary')
         self.summary_type = kwargs.get('summary_type', 'html')
-        self.author = kwargs.get('author')
+        self.author = kwargs.get('author', ())
         self.published = kwargs.get('published')
         self.rights = kwargs.get('rights')
         self.links = kwargs.get('links', [])

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -22,6 +22,7 @@
     :license: BSD, see LICENSE for more details.
 """
 from datetime import datetime
+from six import string_types
 from werkzeug.utils import escape
 from werkzeug.wrappers import BaseResponse
 
@@ -115,7 +116,7 @@ class AtomFeed(object):
         self.entries = entries and list(entries) or []
 
         if not hasattr(self.author, '__iter__') \
-           or isinstance(self.author, (basestring, dict)):
+           or isinstance(self.author, string_types + (dict,)):
             self.author = [self.author]
         for i, author in enumerate(self.author):
             if not isinstance(author, dict):
@@ -283,7 +284,7 @@ class FeedEntry(object):
         self.xml_base = kwargs.get('xml_base', feed_url)
 
         if not hasattr(self.author, '__iter__') \
-           or isinstance(self.author, (basestring, dict)):
+           or isinstance(self.author, string_types + (dict,)):
             self.author = [self.author]
         for i, author in enumerate(self.author):
             if not isinstance(author, dict):

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -14,10 +14,14 @@ from werkzeug.utils import escape
 from werkzeug.wrappers import BaseResponse
 
 
+XHTML_NAMESPACE = 'http://www.w3.org/1999/xhtml'
+
+
 def _make_text_block(name, content, content_type=None):
     """Helper function for the builder that creates an XML text block."""
     if content_type == 'xhtml':
-        return u'<%s type="xhtml">%s</%s>\n' % (name, content, anem)
+        return u'<%s type="xhtml"><div xmlns="%s">%s</div></%s>\n' % \
+               (name, XHTML_NAMESPACE, content, name)
     if not content_type:
         return u'<%s>%s</%s>\n' % (name, escape(content), name)
     return u'<%s type="%s">%s</%s>\n' % (name, content_type,

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -18,7 +18,7 @@
                          updated=post.last_update, published=post.pub_date)
             return feed.get_response()
 
-    :copyright: (c) 2010 by the Werkzeug Team, see AUTHORS for more details.
+    :copyright: (c) 2011 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
 from datetime import datetime

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -3,10 +3,22 @@
     werkzeug.contrib.atom
     ~~~~~~~~~~~~~~~~~~~~~
 
-    This module provides a class called `AtomFeed` which can be used to
-    generate feeds in the Atom syndication format (see `RFC 4287`_).
+    This module provides a class called :class:`AtomFeed` which can be
+    used to generate feeds in the Atom syndication format (see `RFC 4287`_).
 
     .. _RFC 4287: http://tools.ietf.org/html/rfc4287
+
+    Example::
+
+        def atom_feed(request):
+            feed = AtomFeed("My Blog", feed_url=req.url,
+                            url=req.host_url,
+                            subtitle="My example blog for a feed test.")
+            for post in Post.query.limit(10).all():
+                feed.add(post.title, post.body, content_type='html',
+                         author=post.author, url=post.url, id=post.uid,
+                         updated=post.last_update, published=post.pub_date)
+            return feed.get_response()
 
     :copyright: (c) 2009 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
@@ -36,64 +48,55 @@ def format_iso8601(obj):
 
 
 class AtomFeed(object):
-    """A helper class that creates Atom feeds."""
+    """A helper class that creates Atom feeds.
+
+    :param title: the title of the feed. Required.
+    :param title_type: the type attribute for the title element.  One of
+                       ``'html'``, ``'text'`` or ``'xhtml'``.
+    :param url: the url for the feed (not the url *of* the feed)
+    :param id: a globally unique id for the feed.  Must be an URI.  If
+               not present the `feed_url` is used, but one of both is
+               required.
+    :param updated: the time the feed was modified the last time.  Must
+                    be a :class:`datetime.datetime` object.  If not
+                    present the latest entry's `updated` is used.
+    :param feed_url: the URL to the feed.  Should be the URL that was
+                     requested.
+    :param author: the author of the feed.  Must be either a string (the
+                   name) or a dict with name (required) and uri or
+                   email (both optional).  Can be a list of (may be
+                   mixed, too) strings and dicts, too, if there are
+                   multiple authors. Required if not every entry has an
+                   author element.
+    :param icon: an icon for the feed.
+    :param logo: a logo for the feed.
+    :param rights: copyright information for the feed.
+    :param rights_type: the type attribute for the rights element.  One of
+                        ``'html'``, ``'text'`` or ``'xhtml'``.  Default is
+                        ``'text'``.
+    :param subtitle: a short description of the feed.
+    :param subtitle_type: the type attribute for the subtitle element.
+                          One of ``'text'``, ``'html'``, ``'text'``
+                          or ``'xhtml'``.  Default is ``'text'``.
+    :param links: additional links.  Must be a list of dictionaries with
+                  href (required) and rel, type, hreflang, title, length
+                  (all optional)
+    :param generator: the software that generated this feed.  This must be
+                      a tuple in the form ``(name, url, version)``.  If
+                      you don't want to specify one of them, set the item
+                      to `None`.
+    :param entries: a list with the entries for the feed. Entries can also
+                    be added later with :meth:`add`.
+
+    For more information on the elements see
+    http://www.atomenabled.org/developers/syndication/
+
+    Everywhere where a list is demanded, any iterable can be used.
+    """
+
     default_generator = ('Werkzeug', None, None)
 
     def __init__(self, title=None, entries=None, **kwargs):
-        """Create an Atom feed.
-
-        :Parameters:
-          title
-            the title of the feed. Required.
-          title_type
-            the type attribute for the title element. One of html, text,
-            xhtml. Default is text.
-          url
-            the url for the feed (not the url *of* the feed)
-          id
-            a globally unique id for the feed. Must be an URI. If not present
-            the `feed_url` is used, but one of both is required.
-          updated
-            the time the feed was modified the last time. Must be a `datetime`
-            object. If not present the latest entry's `updated` is used.
-          feed_url
-            the url to the feed. Should be the URL that was requested.
-          author
-            the author of the feed. Must be either a string (the name) or a
-            dict with name (required) and uri or email (both optional). Can be
-            a list of (may be mixed, too) strings and dicts, too, if there are
-            multiple authors. Required if not every entry has an author
-            element.
-          icon
-            an icon for the feed.
-          logo
-            a logo for the feed.
-          rights
-            copyright information for the feed.
-          rights_type
-            the type attribute for the rights element. One of html, text,
-            xhtml. Default is text.
-          subtitle
-            a short description of the feed.
-          subtitle_type
-            the type attribute for the subtitle element. One of html, text,
-            xhtml. Default is text.
-          links
-            additional links. Must be a list of dictionaries with href
-            (required) and rel, type, hreflang, title, length (all optional)
-          generator
-            the software that generated this feed.  This must be a tuple in
-            the form ``(name, url, version)``.  If you don't want to specify
-            one of them, set the item to None.
-          entries
-            a list with the entries for the feed. Entries can also be added
-            later with add().
-
-        For more information on the elements see
-        http://www.atomenabled.org/developers/syndication/
-
-        Everywhere where a list is demanded, any iterable can be used.
-        """
         self.title = title
         self.title_type = kwargs.get('title_type', 'text')
         self.url = kwargs.get('url')
@@ -129,7 +132,10 @@ class AtomFeed(object):
                 raise TypeError('author must contain at least a name')
 
     def add(self, *args, **kwargs):
-        """add a new entry to the feed"""
+        """Add a new entry to the feed.  This function can either be called
+        with a :class:`FeedEntry` or some keyword and positional arguments
+        that are forwarded to the :class:`FeedEntry` constructor.
+        """
         if len(args) == 1 and not kwargs and isinstance(args[0], FeedEntry):
             self.entries.append(args[0])
         else:
@@ -219,61 +225,47 @@ class AtomFeed(object):
 
 
 class FeedEntry(object):
-    """Represents a single entry in a feed."""
+    """Represents a single entry in a feed.
+
+    :param title: the title of the entry. Required.
+    :param title_type: the type attribute for the title element.  One of
+                       ``'html'``, ``'text'`` or ``'xhtml'``.
+    :param content: the content of the entry.
+    :param content_type: the type attribute for the content element.  One
+                         of ``'html'``, ``'text'`` or ``'xhtml'``.
+    :param summary: a summary of the entry's content.
+    :param summary_type: the type attribute for the summary element.  One
+                         of ``'html'``, ``'text'`` or ``'xhtml'``.
+    :param url: the url for the entry.
+    :param id: a globally unique id for the entry.  Must be an URI.  If
+               not present the URL is used, but one of both is required.
+    :param updated: the time the entry was modified the last time.  Must
+                    be a :class:`datetime.datetime` object. Required.
+    :param author: the author of the feed.  Must be either a string (the
+                   name) or a dict with name (required) and uri or
+                   email (both optional).  Can be a list of (may be
+                   mixed, too) strings and dicts, too, if there are
+                   multiple authors. Required if not every entry has an
+                   author element.
+    :param published: the time the entry was initially published.  Must
+                      be a :class:`datetime.datetime` object.
+    :param rights: copyright information for the entry.
+    :param rights_type: the type attribute for the rights element.  One of
+                        ``'html'``, ``'text'`` or ``'xhtml'``.  Default is
+                        ``'text'``.
+    :param links: additional links.  Must be a list of dictionaries with
+                  href (required) and rel, type, hreflang, title, length
+                  (all optional)
+    :param xml_base: The xml base (url) for this feed item.  If not provided
+                     it will default to the item url.
+
+    For more information on the elements see
+    http://www.atomenabled.org/developers/syndication/
+
+    Everywhere where a list is demanded, any iterable can be used.
+    """
 
     def __init__(self, title=None, content=None, feed_url=None, **kwargs):
-        """Holds an Atom feed entry.
-
-        :Parameters:
-          title
-            the title of the entry. Required.
-          title_type
-            the type attribute for the title element. One of html, text,
-            xhtml. Default is text.
-          content
-            the content of the entry.
-          content_type
-            the type attribute for the content element. One of html, text,
-            xhtml. Default is text.
-          summary
-            a summary of the entry's content.
-          summary_type
-            a type attribute for the summary element. One of html, text,
-            xhtml. Default is text.
-          url
-            the url for the entry.
-          id
-            a globally unique id for the entry. Must be an URI. If not present
-            the URL is used, but one of both is required.
-          updated
-            the time the entry was modified the last time. Must be a
-            `datetime` object. Required.
-          author
-            the author of the entry. Must be either a string (the name) or a
-            dict with name (required) and uri or email (both optional). Can
-            be a list of (may be mixed, too) strings and dicts, too, if there
-            are multiple authors. Required if there is no author for the
-            feed.
-          published
-            the time the entry was initially published. Must be a `datetime`
-            object.
-          rights
-            copyright information for the entry.
-          rights_type
-            the type attribute for the rights element. One of html, text,
-            xhtml. Default is text.
-          links
-            additional links. Must be a list of dictionaries with href
-            (required) and rel, type, hreflang, title, length (all optional)
-          xml_base
-            The xml base (url) for this feed item.  If not provided it will
-            default to the item url.
-
-        For more information on the elements see
-        http://www.atomenabled.org/developers/syndication/
-
-        Everywhere where a list is demanded, any iterable can be used.
-        """
         self.title = title
         self.title_type = kwargs.get('title_type', 'text')
         self.content = content

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -120,7 +120,7 @@ class AtomFeed(object):
         if self.generator is None:
             self.generator = self.default_generator
         self.links = kwargs.get('links', [])
-        self.entries = entries and list(entries) or []
+        self.entries = list(entries) if entries else []
 
         if not hasattr(self.author, '__iter__') \
            or isinstance(self.author, string_types + (dict,)):
@@ -164,7 +164,7 @@ class AtomFeed(object):
 
         if not self.updated:
             dates = sorted([entry.updated for entry in self.entries])
-            self.updated = dates and dates[-1] or datetime.utcnow()
+            self.updated = dates[-1] if dates else datetime.utcnow()
 
         yield u'<?xml version="1.0" encoding="utf-8"?>\n'
         yield u'<feed xmlns="http://www.w3.org/2005/Atom">\n'

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -44,7 +44,10 @@ def _make_text_block(name, content, content_type=None):
 
 def format_iso8601(obj):
     """Format a datetime object for iso8601"""
-    return obj.strftime('%Y-%m-%dT%H:%M:%SZ')
+    iso8601 = obj.isoformat()
+    if obj.tzinfo:
+        return iso8601
+    return iso8601 + 'Z'
 
 
 @implements_to_string
@@ -61,6 +64,7 @@ class AtomFeed(object):
     :param updated: the time the feed was modified the last time.  Must
                     be a :class:`datetime.datetime` object.  If not
                     present the latest entry's `updated` is used.
+                    Treated as UTC if naive datetime.
     :param feed_url: the URL to the feed.  Should be the URL that was
                      requested.
     :param author: the author of the feed.  Must be either a string (the
@@ -239,7 +243,8 @@ class FeedEntry(object):
     :param id: a globally unique id for the entry.  Must be an URI.  If
                not present the URL is used, but one of both is required.
     :param updated: the time the entry was modified the last time.  Must
-                    be a :class:`datetime.datetime` object. Required.
+                    be a :class:`datetime.datetime` object.  Treated as
+                    UTC if naive datetime. Required.
     :param author: the author of the entry.  Must be either a string (the
                    name) or a dict with name (required) and uri or
                    email (both optional).  Can be a list of (may be
@@ -247,7 +252,8 @@ class FeedEntry(object):
                    multiple authors. Required if the feed does not have an
                    author element.
     :param published: the time the entry was initially published.  Must
-                      be a :class:`datetime.datetime` object.
+                      be a :class:`datetime.datetime` object.  Treated as
+                      UTC if naive datetime.
     :param rights: copyright information for the entry.
     :param rights_type: the type attribute for the rights element.  One of
                         ``'html'``, ``'text'`` or ``'xhtml'``.  Default is

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -18,7 +18,7 @@
                          updated=post.last_update, published=post.pub_date)
             return feed.get_response()
 
-    :copyright: (c) 2011 by the Werkzeug Team, see AUTHORS for more details.
+    :copyright: (c) 2013 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
 from datetime import datetime

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -254,6 +254,8 @@ class FeedEntry(object):
     :param links: additional links.  Must be a list of dictionaries with
                   href (required) and rel, type, hreflang, title, length
                   (all optional)
+    :param categories: categories for the entry. Must be a list of dictionaries
+                       with term (required), scheme and label (all optional)
     :param xml_base: The xml base (url) for this feed item.  If not provided
                      it will default to the item url.
 
@@ -277,6 +279,7 @@ class FeedEntry(object):
         self.published = kwargs.get('published')
         self.rights = kwargs.get('rights')
         self.links = kwargs.get('links', [])
+        self.categories = kwargs.get('categories', [])
         self.xml_base = kwargs.get('xml_base', feed_url)
 
         if not hasattr(self.author, '__iter__') \
@@ -324,6 +327,9 @@ class FeedEntry(object):
         for link in self.links:
             yield u'  <link %s/>\n' % ''.join('%s="%s" ' % \
                 (k, escape(link[k], True)) for k in link)
+        for category in self.categories:
+            yield u'  <category %s/>\n' % ''.join('%s="%s" ' % \
+                (k, escape(category[k], True)) for k in category)
         if self.summary:
             yield u'  ' + _make_text_block('summary', self.summary,
                                            self.summary_type)

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -152,7 +152,7 @@ class AtomFeed(object):
         # atom demands either an author element in every entry or a global one
         if not self.author:
             if False in map(lambda e: bool(e.author), self.entries):
-                self.author = ({'name': u'unbekannter Autor'},)
+                self.author = ({'name': 'Unknown author'},)
 
         if not self.updated:
             dates = sorted([entry.updated for entry in self.entries])

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -22,10 +22,10 @@
     :license: BSD, see LICENSE for more details.
 """
 from datetime import datetime
-from six import string_types
+
 from werkzeug.utils import escape
 from werkzeug.wrappers import BaseResponse
-from werkzeug._compat import implements_to_string
+from werkzeug._compat import implements_to_string, string_types
 
 
 XHTML_NAMESPACE = 'http://www.w3.org/1999/xhtml'

--- a/lektor_atom/lib/atom.py
+++ b/lektor_atom/lib/atom.py
@@ -21,20 +21,13 @@
     :copyright: 2007 Pallets
     :license: BSD-3-Clause
 """
-import warnings
 from datetime import datetime
 
-from .._compat import implements_to_string
-from .._compat import string_types
-from ..utils import escape
-from ..wrappers import BaseResponse
+from werkzeug._compat import implements_to_string
+from werkzeug._compat import string_types
+from werkzeug.utils import escape
+from werkzeug.wrappers import BaseResponse
 
-warnings.warn(
-    "'werkzeug.contrib.atom' is deprecated as of version 0.15 and will"
-    " be removed in version 1.0.",
-    DeprecationWarning,
-    stacklevel=2,
-)
 
 XHTML_NAMESPACE = "http://www.w3.org/1999/xhtml"
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     name="lektor-atom",
     packages=["lektor_atom"],
     url="https://github.com/lektor/lektor-atom",
-    version="0.3.1",
+    version="0.3.2",
     classifiers=[
         "Environment :: Plugins",
         "Environment :: Web Environment",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with io.open("README.md", "rt", encoding="utf8") as f:
 
 _description_re = re.compile(r"description\s+=\s+(?P<description>.*)")
 
-with open("lektor_atom.py", "rb") as f:
+with open("lektor_atom/__init__.py", "rb") as f:
     description = str(
         ast.literal_eval(_description_re.search(f.read().decode("utf-8")).group(1))
     )
@@ -23,14 +23,14 @@ setup(
     description=description,
     install_requires=[
         "MarkupSafe",
-        "Werkzeug<1.0",  # Werkzeug 1.0 removed the feed generator
+        "Werkzeug",
     ],
     keywords="Lektor plugin static-site blog atom rss",
     license="MIT",
     long_description=readme,
     long_description_content_type="text/markdown",
     name="lektor-atom",
-    py_modules=["lektor_atom"],
+    packages=["lektor_atom"],
     url="https://github.com/lektor/lektor-atom",
     version="0.3.1",
     classifiers=[


### PR DESCRIPTION
I have imported `atom.py` into `lib/` from werkzeug 0.16, preserving all history. I used git-filter-repo for the job.

The only relevant commits are the last ones.