### PR TITLE
Disable extras_require as that kills installation via lektor.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,6 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     entry_points={"lektor.plugins": ["atom = lektor_atom:AtomPlugin"]},
-    extras_require={"test": tests_require},
+    # extras_require={"test": tests_require},
     tests_require=tests_require,
 )


### PR DESCRIPTION
This is likely a bug in lektor (see https://github.com/lektor/lektor/issues/865) but until that is fixed, it is probably best to disable this, so this can actually be installed from GitHub.