### PR TITLE
Fix #10

### DIFF
--- a/lektor_atom.py
+++ b/lektor_atom.py
@@ -44,6 +44,9 @@ class AtomFeedSource(VirtualSourceObject):
 
         return build_url([self.parent.url_path, self.filename])
 
+    def iter_source_filenames(self):
+        return self.record.iter_source_filenames()
+
     def __getattr__(self, item):
         try:
             return self.plugin.get_atom_config(self.feed_id, item)


### PR DESCRIPTION
Here is a fix for #10.

The issue is that `AtomFeedSource.iter_source_filenames` (inherited from `lektor.sourceobj.VirtualSourceObject`) only returns the single primary source file for the virtual source.  As a result, the resulting artifact for the feed in the build-state database gets only one primary source file.

I.e. (assuming alt=en) both `blog/contents+en.lr` and `blog/contents.lr` should be listed as primary source files.  As things were, only the alternative-specific `blog/contents+en.lr` was being listed as a primary source.  (Artifacts get pruned if none of their primary source files exist.)

----

## Questions

I'm not quite sure that this fix really belongs here in `AtomFeedSource`.  Maybe it should moved up to `lektor.sourceobj.VirtualSourceObject.iter_source_filenames`?
